### PR TITLE
Fixes #7 and #6  - updating mvn rpm plugin version and bumping versions

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -3,10 +3,10 @@
     <parent>
         <groupId>org.esbtools.message.admin</groupId>
         <artifactId>esb-message-admin-pom</artifactId>
-        <version>0.3.SNAPSHOT</version>
+        <version>0.4-SNAPSHOT</version>
     </parent>
     <artifactId>esb-message-admin-app</artifactId>
-    <version>0.1.3.SNAPSHOT</version>
+    <version>0.1.4-SNAPSHOT</version>
     <packaging>war</packaging>
     <name>esb-message-admin: ${project.groupId}|${project.artifactId}</name>
     <licenses>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -109,6 +109,7 @@
                             <requires>
                                 <require>jbossas-standalone &gt;= 7</require>
                             </requires>
+                            <sourceEncoding>UTF-8</sourceEncoding>
                             <mappings>
                                 <mapping>
                                     <directory>/var/lib/jbossas/standalone/deployments</directory>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -90,7 +90,7 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>rpm-maven-plugin</artifactId>
-                        <version>2.1-alpha-3</version>
+                        <version>2.1.2</version>
                         <executions>
                             <execution>
                                 <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <groupId>org.esbtools.message.admin</groupId>
     <artifactId>esb-message-admin-pom</artifactId>
     <packaging>pom</packaging>
-    <version>0.3.SNAPSHOT</version>
+    <version>0.4-SNAPSHOT</version>
     <name>esb-message-admin: ${project.groupId}|${project.artifactId}</name>
     <description>ESB Error Message Management Tool</description>
     <url></url>

--- a/service-client/pom.xml
+++ b/service-client/pom.xml
@@ -7,10 +7,10 @@
     <parent>
         <groupId>org.esbtools.message.admin</groupId>
         <artifactId>esb-message-admin-pom</artifactId>
-        <version>0.3.SNAPSHOT</version>
+        <version>0.4-SNAPSHOT</version>
     </parent>
     <artifactId>esb-message-admin-service-client</artifactId>
-    <version>0.1.SNAPSHOT</version>
+    <version>0.2-SNAPSHOT</version>
     <name>esb-message-admin: ${project.groupId}|${project.artifactId}</name>
     <dependencies>
         <dependency>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <groupId>org.esbtools.message.admin</groupId>
         <artifactId>esb-message-admin-pom</artifactId>
-        <version>0.3.SNAPSHOT</version>
+        <version>0.4-SNAPSHOT</version>
     </parent>
     <groupId>org.esbtools.message.admin</groupId>
     <artifactId>esb-message-admin-service</artifactId>
-    <version>0.3.SNAPSHOT</version>
+    <version>0.4-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>esb-message-admin: ${project.groupId}|${project.artifactId}</name>
     <dependencies>

--- a/spi/pom.xml
+++ b/spi/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <groupId>org.esbtools.message.admin</groupId>
         <artifactId>esb-message-admin-pom</artifactId>
-        <version>0.3.SNAPSHOT</version>
+        <version>0.4-SNAPSHOT</version>
     </parent>
     <groupId>org.esbtools.message.admin</groupId>
     <artifactId>esb-message-admin-spi</artifactId>
-    <version>0.1.3.SNAPSHOT</version>
+    <version>0.1.4-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>esb-message-admin: ${project.groupId}|${project.artifactId}</name>
     <licenses>


### PR DESCRIPTION
1. updated mvn rpm version to 2.1.2 and added source Encoding to successfuly build the rpm.
2. bumped version to 0.4-SNAPSHOT