### PR TITLE
 encrypt sensitive information

### DIFF
--- a/common/src/main/java/org/esbtools/message/admin/common/ConversionUtility.java
+++ b/common/src/main/java/org/esbtools/message/admin/common/ConversionUtility.java
@@ -27,6 +27,7 @@ import java.util.Set;
 
 import org.esbtools.message.admin.common.orm.EsbMessageEntity;
 import org.esbtools.message.admin.common.orm.EsbMessageHeaderEntity;
+import org.esbtools.message.admin.common.orm.EsbMessageSensitiveInfoEntity;
 import org.esbtools.message.admin.common.orm.MetadataEntity;
 import org.esbtools.message.admin.model.EsbMessage;
 import org.esbtools.message.admin.model.Header;
@@ -172,6 +173,16 @@ public class ConversionUtility {
         List<MetadataField> result = new ArrayList<MetadataField>(entities.size());
         for (MetadataEntity entity : entities) {
             result.add(convertToMetadataField(entity));
+        }
+        return result;
+    }
+
+    public static List<EsbMessageSensitiveInfoEntity> convertToEsbMessageSensitiveInfo(EncryptionUtil encrypter, EsbMessageEntity eme, List<String> sensitiveInfo) {
+        List<EsbMessageSensitiveInfoEntity> result = new ArrayList<EsbMessageSensitiveInfoEntity>();
+        if(sensitiveInfo!=null) {
+            for(String text: sensitiveInfo) {
+                result.add(new EsbMessageSensitiveInfoEntity(eme, encrypter.encrypt(text)));
+            }
         }
         return result;
     }

--- a/common/src/main/java/org/esbtools/message/admin/common/EncryptionUtil.java
+++ b/common/src/main/java/org/esbtools/message/admin/common/EncryptionUtil.java
@@ -1,0 +1,54 @@
+package org.esbtools.message.admin.common;
+
+import java.io.UnsupportedEncodingException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.util.logging.Logger;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.apache.commons.codec.binary.Base64;
+
+public class EncryptionUtil {
+
+    private final static Logger log = Logger.getLogger(EncryptionUtil.class.getName());
+    private static final String ALGORITHM = "AES/ECB/PKCS5Padding";
+    private final String encryptionKey;
+    public EncryptionUtil(String key) {
+        this.encryptionKey = key;
+    }
+
+    public String encrypt(String sensitiveInfo) {
+        try {
+            Cipher cipher = Cipher.getInstance(ALGORITHM, "SunJCE");
+            SecretKeySpec key = new SecretKeySpec(encryptionKey.getBytes("UTF-8"), "AES");
+            cipher.init(Cipher.ENCRYPT_MODE, key);
+            return Base64.encodeBase64String(cipher.doFinal(sensitiveInfo.getBytes("UTF-8")));
+        } catch(NoSuchAlgorithmException | NoSuchProviderException | NoSuchPaddingException
+                | UnsupportedEncodingException | InvalidKeyException | IllegalBlockSizeException
+                | BadPaddingException e) {
+            log.severe("EMA Encryption error!"+e);
+            return null;
+        }
+    }
+
+    public String decrypt(String encryptedInfo) {
+        try {
+            Cipher cipher = Cipher.getInstance(ALGORITHM, "SunJCE");
+            SecretKeySpec key = new SecretKeySpec(encryptionKey.getBytes("UTF-8"), "AES");
+            cipher.init(Cipher.DECRYPT_MODE, key);
+            return new String(cipher.doFinal(Base64.decodeBase64(encryptedInfo.getBytes("UTF-8")))).trim();
+        } catch(NoSuchAlgorithmException | NoSuchProviderException | NoSuchPaddingException
+                | UnsupportedEncodingException | InvalidKeyException | IllegalBlockSizeException
+                | BadPaddingException e) {
+            log.severe("EMA Decryption error!"+e);
+            return null;
+        }
+    }
+
+}

--- a/common/src/test/java/org/esbtools/message/admin/common/EncrypterUtilTest.java
+++ b/common/src/test/java/org/esbtools/message/admin/common/EncrypterUtilTest.java
@@ -1,0 +1,45 @@
+/*
+ Copyright 2015 esbtools Contributors and/or its affiliates.
+
+ This file is part of esbtools.
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.esbtools.message.admin.common;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit test to demonstrate using the KeyExtractor Util
+ *
+ * @author ykoer
+ */
+
+public class EncrypterUtilTest {
+
+    @Test
+    public void testEncrypter() {
+        EncryptionUtil util = new EncryptionUtil("myPassisBIG12345");
+        Assert.assertNotEquals("text", util.encrypt("text"));
+        Assert.assertEquals("text", util.decrypt(util.encrypt("text")));
+    }
+
+    @Test
+    public void testEncrypterDoesntWorkWithDifferentPassword() {
+        EncryptionUtil util = new EncryptionUtil("myPassisBIG12345");
+        EncryptionUtil util2 = new EncryptionUtil("myPassisBIG12346");
+        Assert.assertNull((util2.decrypt(util.encrypt("text"))));
+    }
+}

--- a/common/src/test/resources/security.txt
+++ b/common/src/test/resources/security.txt
@@ -1,0 +1,1 @@
+passwordpassword


### PR DESCRIPTION
@derek63 
* automatic Attribute conversion requires wildfly, so we have to encrypt things manually for now
* we cant merge this in until puppet work for password file is complete
* password is required to be 16 chars or multiples
* assuming that we no longer need to persist sensitive info into different schema as information is encrypted. advantage of using the same schema is ability to use the same entity manager, and therefore jpql join annotations
