### PR TITLE
Jetty

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -217,5 +217,69 @@
             </resources>
         </build>
     </profile>
+    <profile>
+      <id>jetty</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.jboss.resteasy</groupId>
+          <artifactId>resteasy-servlet-initializer</artifactId>
+          <version>3.0.7.Final</version>
+        </dependency>
+        <dependency>
+          <groupId>org.jboss.resteasy</groupId>
+          <artifactId>resteasy-jaxrs</artifactId>
+          <version>3.0.7.Final</version>
+        </dependency>
+        <dependency>
+          <groupId>org.jboss.weld.servlet</groupId>
+          <artifactId>weld-servlet</artifactId>
+          <version>2.2.15.Final</version>
+        </dependency>
+        <dependency>
+          <groupId>org.hibernate</groupId>
+          <artifactId>hibernate-entitymanager</artifactId>
+          <version>4.2.2.Final</version>
+          <scope>compile</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.hibernate.javax.persistence</groupId>
+          <artifactId>hibernate-jpa-2.0-api</artifactId>
+          <version>1.0.1.Final</version>
+          <scope>compile</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.jboss.resteasy</groupId>
+          <artifactId>resteasy-cdi</artifactId>
+          <version>3.0.7.Final</version>
+        </dependency>
+        <dependency>
+          <groupId>org.jboss.resteasy</groupId>
+          <artifactId>resteasy-jackson-provider</artifactId>
+          <version>3.0.7.Final</version>
+        </dependency>
+        <dependency>
+          <groupId>org.hsqldb</groupId>
+          <artifactId>hsqldb</artifactId>
+          <version>2.2.8</version>
+          <scope>compile</scope>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-maven-plugin</artifactId>
+            <version>9.2.8.v20150217</version>
+            <configuration>
+              <webApp>
+                <descriptor>${project.basedir}/src/test/webapp/WEB-INF/web.xml</descriptor>
+              </webApp>
+              <!-- use persistence.xml from src/test/resources -->
+              <useTestScope>true</useTestScope>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 </project>

--- a/app/src/test/resources/META-INF/persistence.xml
+++ b/app/src/test/resources/META-INF/persistence.xml
@@ -1,0 +1,22 @@
+<persistence xmlns="http://java.sun.com/xml/ns/persistence"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_1_0.xsd"
+   version="1.0">
+   <persistence-unit name="EsbMessageAdminPU">
+      <class>org.esbtools.message.admin.common.orm.EsbMessageEntity</class>
+      <class>org.esbtools.message.admin.common.orm.EsbMessageHeaderEntity</class>
+      <class>org.esbtools.message.admin.common.orm.EsbMessageSensitiveInfoEntity</class>
+      <class>org.esbtools.message.admin.common.orm.MetadataEntity</class>
+      <class>org.esbtools.message.admin.common.orm.AuditEventEntity</class>
+       <properties>
+         <property name="hibernate.dialect" value="org.hibernate.dialect.HSQLDialect"/>
+         <property name="hibernate.connection.driver_class" value="org.hsqldb.jdbcDriver"/>
+         <property name="hibernate.connection.username" value="sa"/>
+         <property name="hibernate.connection.password" value=""/>
+         <property name="hibernate.connection.url" value="jdbc:hsqldb:mem:esbmessageadmin;sql.syntax_mys=true"/>
+         <property name="hibernate.max_fetch_depth" value="3"/>
+         <property name="hibernate.show_sql" value="true" />
+         <property name="hibernate.hbm2ddl.auto" value="create"/>
+      </properties>
+   </persistence-unit>
+</persistence>

--- a/app/src/test/resources/config.json
+++ b/app/src/test/resources/config.json
@@ -1,0 +1,59 @@
+{
+    "suggestedFields":[
+        "SourceSystem",
+        "ErrorSystem",
+        "MessageType",
+        "SourceQueue"
+    ],
+    "sortingFields":[
+        "id",
+        "timestamp",
+        "messageType",
+        "sourceSystem",
+        "errorSystem",
+        "occurrenceCount"
+    ],
+    "nonViewableMessages":[
+        {
+            "matchCriteria":{
+                "messageType":"EntityOne",
+                "sourceSystem":"SourceSystemOne"
+            },
+            "configuration":{
+                "replaceMessage":"EntityOne messages from SourceSystemOne are restricted"
+            }
+        },
+        {
+            "matchCriteria":{
+                "sourceSystem":"SourceSystemTwo"
+            },
+            "configuration":{
+                "replaceMessage":"SourceSystemTwo messages are restricted"
+            }
+        }
+    ],
+    "partiallyViewableMessages":[
+        {
+            "matchCriteria":{
+                "messageType":"PartialEntityOne",
+                "sourceSystem":"PartiaSourceSystemOne"
+            },
+            "configuration":{
+                "sensitiveTag":"Example",
+                "replacementText":"Sensitive Information is not viewable"
+            }
+        },
+        {
+            "matchCriteria":{
+                "messageType":"PartialEntityTwo"
+            },
+            "configuration":{
+                "searchRegex":"\"(Example)\":\\{(?:[^{}]*|(?:\\{[^{}]*\\}))*\\}",
+                "replaceRegex":"\"$1\":\"MASKED\""
+            }
+        }
+    ],
+    "resyncRestEndpoints":[
+        "https://localhost/emagateway/resync",
+    ]
+}

--- a/app/src/test/resources/encryption.key
+++ b/app/src/test/resources/encryption.key
@@ -1,0 +1,1 @@
+passwordpassword

--- a/app/src/test/resources/import.sql
+++ b/app/src/test/resources/import.sql
@@ -1,0 +1,2 @@
+INSERT INTO METADATA (id, name, parent_id, type, value) values (1, 'SearchKeys', -1, 'SearchKeys', 'SearchKeys');
+INSERT INTO METADATA (id, name, parent_id, type, value) values (2, 'Entities', -1, 'Entities', 'Entities');

--- a/app/src/test/webapp/WEB-INF/web.xml
+++ b/app/src/test/webapp/WEB-INF/web.xml
@@ -1,0 +1,10 @@
+<web-app version="3.0" xmlns="http://java.sun.com/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
+    <listener>
+        <listener-class>org.jboss.weld.environment.servlet.BeanManagerResourceBindingListener</listener-class>
+    </listener>
+    <listener>
+        <listener-class>org.jboss.weld.environment.servlet.Listener</listener-class>
+    </listener>
+</web-app>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -45,6 +45,10 @@
             <artifactId>javax.inject</artifactId>
         </dependency>
         <dependency>
+            <groupId>javax.enterprise</groupId>
+            <artifactId>cdi-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.hibernate.javax.persistence</groupId>
             <artifactId>hibernate-jpa-2.0-api</artifactId>
         </dependency>

--- a/common/src/main/java/org/esbtools/message/admin/common/EsbMessageAdminServiceImpl.java
+++ b/common/src/main/java/org/esbtools/message/admin/common/EsbMessageAdminServiceImpl.java
@@ -25,9 +25,9 @@ import java.io.InputStreamReader;
 import java.util.*;
 import java.util.logging.Logger;
 
+import javax.inject.Inject;
 import javax.inject.Named;
 import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
 
 import org.esbtools.message.admin.Provider;
 import org.esbtools.message.admin.common.dao.AuditEventDAO;
@@ -51,9 +51,6 @@ import org.json.simple.parser.JSONParser;
 @Named
 public class EsbMessageAdminServiceImpl implements Provider {
 
-    @PersistenceContext(unitName = "EsbMessageAdminPU")
-    private EntityManager entityMgr;
-
     private static final Logger LOG = Logger.getLogger(EsbMessageAdminServiceImpl.class.getName());
     private JSONObject config;
     private String encryptionKey;
@@ -62,6 +59,9 @@ public class EsbMessageAdminServiceImpl implements Provider {
     private transient AuditEventDAO auditDao;
     private static transient KeyExtractorUtil extractor;
     private static transient EncryptionUtil encrypter;
+
+    @Inject
+    private EntityManager entityMgr;
 
     {
         try {

--- a/common/src/main/java/org/esbtools/message/admin/common/utility/EntityManagerProvider.java
+++ b/common/src/main/java/org/esbtools/message/admin/common/utility/EntityManagerProvider.java
@@ -1,0 +1,42 @@
+package org.esbtools.message.admin.common.utility;
+
+import javax.enterprise.inject.Disposes;
+import javax.enterprise.inject.Produces;
+import javax.inject.Named;
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Persistence;
+import javax.persistence.PersistenceContext;
+
+@Named
+class EntityManagerProvider {
+    @PersistenceContext(unitName = "EsbMessageAdminPU")
+    private EntityManager entityMgr;
+
+    private static EntityManagerFactory EMF;
+
+    @Produces
+    public EntityManager getEntityManager() {
+        /* if running in container which doesn't support @PersistenceContext
+         * (such as jetty), manually create the EntityManager. */
+        if (entityMgr == null) {
+            synchronized(EntityManagerProvider.class) {
+                if (EMF == null) {
+                    EMF = Persistence.createEntityManagerFactory("EsbMessageAdminPU");
+                }
+            }
+            entityMgr = EMF.createEntityManager();
+            entityMgr.getTransaction().begin();
+        }
+        return entityMgr;
+    }
+
+    public void closeEntityManager(@Disposes EntityManager em) {
+        /* if running in a lightweight container (such as jetty), commit the
+         * transaction and close the EntityManager */
+        if (EMF != null) {
+            em.getTransaction().commit();
+            em.close();
+        }
+    }
+}


### PR DESCRIPTION
Enable local development with `mvn -P jetty jetty:run -pl app`.

Required changing how we manage the `EntityManager`, to emulate how JBoss/Wildfly work with CDI/`@PersistenceContext`.

Fixes #15.