### PR TITLE
Reload page on SAML redirect on AJAX request (fixes #77)

### DIFF
--- a/app/src/main/webapp/js/esbMessageAdminApp.js
+++ b/app/src/main/webapp/js/esbMessageAdminApp.js
@@ -1,43 +1,43 @@
-var esbMessageAdminApp = angular.module('esbMessageAdminApp', 
-	[ 
+var esbMessageAdminApp = angular.module('esbMessageAdminApp',
+	[
 	 	'ui.bootstrap',
-	 	'ngRoute', 
-	 	'ngGrid', 
+	 	'ngRoute',
+	 	'ngGrid',
 	 	'esbMessageAdminControllers',
-	 	'esbMessageAdminServices', 
-	 	'angucomplete', 
+	 	'esbMessageAdminServices',
+	 	'angucomplete',
 	 	'angular-loading-bar',
-	 	'ngQuickDate', 
-	 	'MessageCenterModule', 
-	 	'ui.layout' 
+	 	'ngQuickDate',
+	 	'MessageCenterModule',
+	 	'ui.layout'
 	]
 );
 
 esbMessageAdminApp.config(
 	[
-		'$routeProvider', 
+		'$routeProvider',
 		function($routeProvider) {
-			$routeProvider.when('/errors', 
+			$routeProvider.when('/errors',
 		    	{
 		    		title : "Errors and Messages",
 		    		templateUrl : 'partials/errors.html',
 		    	}
-			).when('/sync', 
+			).when('/sync',
 				{
 					title : "Sync",
 					templateUrl : 'partials/sync.html',
 				}
-			).when('/synckeys', 
+			).when('/synckeys',
 				{
 					title : "Sync Keys",
 					templateUrl : 'partials/synckeys.html',
 				}
-			).when('/searchkeys', 
+			).when('/searchkeys',
 				{
 					title : "Search Keys",
 					templateUrl : 'partials/searchkeys.html',
 				}
-			).when('/users', 
+			).when('/users',
 				{
 					title : "Users",
 					templateUrl : 'partials/users.html',
@@ -47,7 +47,7 @@ esbMessageAdminApp.config(
 					redirectTo : '/errors'
 				}
 			);
-		} 
+		}
 	]
 );
 
@@ -56,33 +56,33 @@ esbMessageAdminApp.run(
 		'$location',
 		'$rootScope',
 		function($location, $rootScope) {
-		    $rootScope.$on('$routeChangeSuccess', 
+		    $rootScope.$on('$routeChangeSuccess',
 		    	function(event, current, previous) {
 		        	if (current.$$route) {
 		        		$rootScope.title = current.$$route.title;
 		        	}
 		    	}
 		    );
-	    } 
+	    }
 	]
 );
 
-esbMessageAdminApp.provider('Globals', 
+esbMessageAdminApp.provider('Globals',
 	function() {
 	    var self = this;
-	
+
 	    // providers are initialized before services
 	    // this guarantees that Globals is setup first
-	    self.$get = [ '$window', 
+	    self.$get = [ '$window',
 	        function($window) {
 		        var globals = {
-		            'dateFormat' : 
+		            'dateFormat' :
 		            {
 		                'service' : 'yyyy-MM-ddTHH:mm:ss',
 		                'datepicker' : 'yyyy/MM/dd',
 		                'timepicker' : 'HH:mm:ss'
 		            },
-		            'serverSideLogging' : 
+		            'serverSideLogging' :
 		            {
 		                'info' : false,
 		                'debug' : false,
@@ -91,13 +91,51 @@ esbMessageAdminApp.provider('Globals',
 		            }
 		        };
 		        return globals;
-	    	} 
+	    	}
 	    ];
 	}
 );
 
+esbMessageAdminApp.factory('samlResponseInterceptor', ['localStorage', '$window', '$timeout',
+  function(localStorage, $window, $timeout) {
+    function jqElementContainsSamlRequest(jqElement) {
+      for (var i = 0; i < jqElement.length; i++) {
+        var e = jqElement[i];
+        if (e.tagName === 'FORM' &&
+          e.querySelector('input[name="SAMLRequest"]') !== null) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    return {
+      response: function(response) {
+        var contentType = response.headers('Content-Type');
+
+        if (contentType !== null && contentType.indexOf("text/html") !== -1) {
+          var responseAsJqElement = angular.element(response.data);
+
+          if (jqElementContainsSamlRequest(responseAsJqElement)) {
+            // Schedule reload on next tick to let xhr request finish normally.
+            $timeout(function() {
+              $window.location.reload();
+            });
+          }
+        }
+
+        return response;
+      }
+    };
+  }
+]);
+
+esbMessageAdminApp.config(['$httpProvider', function($httpProvider) {
+  $httpProvider.interceptors.push('samlResponseInterceptor');
+}]);
+
 String.prototype.supplant = function(o) {
-    return this.replace(/{([^{}]*)}/g, 
+    return this.replace(/{([^{}]*)}/g,
     	function(a, b) {
         	var r = o[b];
         	return typeof r === 'string' || typeof r === 'number' ? r : a;

--- a/app/src/main/webapp/js/esbMessageAdminApp.js
+++ b/app/src/main/webapp/js/esbMessageAdminApp.js
@@ -96,8 +96,8 @@ esbMessageAdminApp.provider('Globals',
 	}
 );
 
-esbMessageAdminApp.factory('samlResponseInterceptor', ['localStorage', '$window', '$timeout',
-  function(localStorage, $window, $timeout) {
+esbMessageAdminApp.factory('samlResponseInterceptor', ['$window', '$timeout',
+  function($window, $timeout) {
     function jqElementContainsSamlRequest(jqElement) {
       for (var i = 0; i < jqElement.length; i++) {
         var e = jqElement[i];

--- a/app/src/test/webapp/js/samlresponseinterceptor.test.js
+++ b/app/src/test/webapp/js/samlresponseinterceptor.test.js
@@ -1,0 +1,62 @@
+describe("samlResponseInterceptor", function() {
+  var $http, $httpBackend, $timeout, $window;
+
+  beforeEach(module("esbMessageAdminApp"));
+
+  beforeEach(module(function($provide) {
+    // Stub window to just toggle wasReloaded() instead of actually reloading.
+    $provide.service('$window', function() {
+      var wasReloaded = false;
+      return {
+        location: {
+          reload: function() {
+            wasReloaded = true;
+          }
+        },
+        wasReloaded: function() {
+          return wasReloaded;
+        }
+      };
+    });
+  }));
+
+  beforeEach(inject(function(_$http_, _$httpBackend_, _$timeout_, _$window_) {
+    $http = _$http_;
+    $httpBackend = _$httpBackend_;
+    $timeout = _$timeout_;
+    $window = _$window_;
+  }));
+
+  it("refreshes window in $timeout if response is a SAML HTML redirect page", function() {
+    $httpBackend.whenGET('foo').respond(
+      '<HTML><HEAD><TITLE>HTTP Post Binding (Request)</TITLE></HEAD><BODY Onload="document.forms[0].submit()"><FORM METHOD="POST" ACTION="https://saml.redhat.com/idp/"><INPUT TYPE="HIDDEN" NAME="SAMLRequest" VALUE="foobar"/></FORM></BODY></HTML>',
+      {
+        "Content-Type": "text/html"
+      }
+    );
+
+    $http.get('foo').then(function() {});
+    $httpBackend.flush();
+
+    expect($window.wasReloaded()).toEqual(false);
+
+    $timeout.flush();
+
+    expect($window.wasReloaded()).toEqual(true);
+  });
+
+  it("does not refresh window if not a SAML HTML redirect response", function() {
+    $httpBackend.whenGET('foo').respond(
+      '<html><body>hey look at me being a template and not a saml response</body></html>',
+      {
+        "Content-Type": "text/html"
+      }
+    );
+
+    $http.get('foo').then(function() {});
+    $httpBackend.flush();
+    $timeout.flush();
+
+    expect($window.wasReloaded()).toEqual(false);
+  });
+});

--- a/app/src/test/webapp/js/samlresponseinterceptor.test.js
+++ b/app/src/test/webapp/js/samlresponseinterceptor.test.js
@@ -5,7 +5,7 @@ describe("samlResponseInterceptor", function() {
 
   beforeEach(module(function($provide) {
     // Stub window to just toggle wasReloaded() instead of actually reloading.
-    $provide.service('$window', function() {
+    $provide.service("$window", function() {
       var wasReloaded = false;
       return {
         location: {
@@ -29,7 +29,7 @@ describe("samlResponseInterceptor", function() {
 
   it("refreshes window in $timeout if response is a SAML HTML redirect page", function() {
     $httpBackend.whenGET('foo').respond(
-      '<HTML><HEAD><TITLE>HTTP Post Binding (Request)</TITLE></HEAD><BODY Onload="document.forms[0].submit()"><FORM METHOD="POST" ACTION="https://saml.redhat.com/idp/"><INPUT TYPE="HIDDEN" NAME="SAMLRequest" VALUE="foobar"/></FORM></BODY></HTML>',
+      '<HTML><HEAD><TITLE>HTTP Post Binding (Request)</TITLE></HEAD><BODY Onload="document.forms[0].submit()"><FORM METHOD="POST" ACTION="https://saml.esbtools.org/"><INPUT TYPE="HIDDEN" NAME="SAMLRequest" VALUE="foobar"/></FORM></BODY></HTML>',
       {
         "Content-Type": "text/html"
       }
@@ -53,7 +53,7 @@ describe("samlResponseInterceptor", function() {
       }
     );
 
-    $http.get('foo').then(function() {});
+    $http.get("foo").then(function() {});
     $httpBackend.flush();
     $timeout.flush();
 


### PR DESCRIPTION
Will cause SAML login page to load just like other non-single-page-apps do when a user's SAML session times out or cookies are cleared.