### PR TITLE
refactored rpm build

### DIFF
--- a/app-saml-auth/pom.xml
+++ b/app-saml-auth/pom.xml
@@ -20,8 +20,8 @@
         </license>
     </licenses>
     <properties>
-        <rpm.release>1</rpm.release>
         <rpm.group>ESB Message Admin Application w/ SAML Auth</rpm.group>
+        <rpm.build.disabled>false</rpm.build.disabled>
     </properties>
     <dependencies>
         <dependency>
@@ -63,76 +63,4 @@
             </resource>
         </resources>
     </build>
-    <profiles>
-      <profile>
-        <id>rpm</id>
-        <!-- RPM packing -->
-        <build>
-            <plugins>
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>rpm-maven-plugin</artifactId>
-                    <version>2.1.2</version>
-                    <executions>
-                        <execution>
-                            <goals>
-                                <goal>attached-rpm</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                    <configuration>
-                        <name>esb-message-admin-${project.artifactId}</name>
-                        <release>${rpm.release}</release>
-                        <group>${rpm.group}</group>
-                        <copyright>${rpm.copyright}</copyright>
-                        <summary>${rpm.summary}</summary>
-                        <epoch>1</epoch>
-                        <buildSRPM>true</buildSRPM>
-                        <requires>
-                            <require>jboss-fsw &gt;= 6</require>
-                        </requires>
-                        <sourceEncoding>${project.build.sourceEncoding}</sourceEncoding>
-                        <mappings>
-                            <mapping>
-                                <directory>${rpm.war.directory}</directory>
-                                <filemode>${rpm.filemode}</filemode>
-                                <username>${rpm.username}</username>
-                                <groupname>${rpm.groupname}</groupname>
-                                <sources>
-                                    <source>
-                                        <location>target/${project.artifactId}-${project.version}.war</location>
-                                    </source>
-                                </sources>
-                            </mapping>
-                            <mapping>
-                                <directory>${rpm.jcliff.directory}</directory>
-                                <filemode>${rpm.filemode}</filemode>
-                                <username>${rpm.username}</username>
-                                <groupname>${rpm.groupname}</groupname>
-                                <sources>
-                                    <source>
-                                      <location>${project.build.outputDirectory}/${project.artifactId}.deploy</location>
-                                    </source>
-                                </sources>
-                            </mapping>
-                        </mappings>
-                    </configuration>
-                </plugin>
-            </plugins>
-            <resources>
-                <resource>
-                    <directory>src/main/resources</directory>
-                    <filtering>false</filtering>
-                    <excludes>
-                        <exclude>deploy/*.deploy</exclude>
-                    </excludes>
-                </resource>
-                <resource>
-                    <directory>src/main/resources/deploy</directory>
-                    <filtering>true</filtering>
-                </resource>
-            </resources>
-        </build>
-    </profile>
-  </profiles>
 </project>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -76,7 +76,7 @@
     </dependencies>
     <properties>
         <rpm.summary>ESB Message Admin Application</rpm.summary>
-        <rpm.release>1</rpm.release>
+        <rpm.build.disabled>false</rpm.build.disabled>
     </properties>
     <build>
         <plugins>
@@ -155,76 +155,6 @@
         </resources>
     </build>
     <profiles>
-      <profile>
-        <id>rpm</id>
-        <!-- RPM packing -->
-        <build>
-            <plugins>
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>rpm-maven-plugin</artifactId>
-                    <version>2.1.2</version>
-                    <executions>
-                        <execution>
-                            <goals>
-                                <goal>attached-rpm</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                    <configuration>
-                        <name>esb-message-admin-${project.artifactId}</name>
-                        <release>${rpm.release}</release>
-                        <group>${rpm.group}</group>
-                        <copyright>${rpm.copyright}</copyright>
-                        <summary>${rpm.summary}</summary>
-                        <epoch>1</epoch>
-                        <buildSRPM>true</buildSRPM>
-                        <requires>
-                            <require>jboss-fsw &gt;= 6</require>
-                        </requires>
-                        <sourceEncoding>${project.build.sourceEncoding}</sourceEncoding>
-                        <mappings>
-                            <mapping>
-                                <directory>${rpm.war.directory}</directory>
-                                <filemode>${rpm.filemode}</filemode>
-                                <username>${rpm.username}</username>
-                                <groupname>${rpm.groupname}</groupname>
-                                <sources>
-                                    <source>
-                                        <location>target/${project.artifactId}-${project.version}.war</location>
-                                    </source>
-                                </sources>
-                            </mapping>
-                            <mapping>
-                                <directory>${rpm.jcliff.directory}</directory>
-                                <filemode>${rpm.filemode}</filemode>
-                                <username>${rpm.username}</username>
-                                <groupname>${rpm.groupname}</groupname>
-                                <sources>
-                                    <source>
-                                      <location>${project.build.outputDirectory}/${project.artifactId}.deploy</location>
-                                    </source>
-                                </sources>
-                            </mapping>
-                        </mappings>
-                    </configuration>
-                </plugin>
-            </plugins>
-            <resources>
-                <resource>
-                    <directory>src/main/resources</directory>
-                    <filtering>false</filtering>
-                    <excludes>
-                        <exclude>deploy/*.deploy</exclude>
-                    </excludes>
-                </resource>
-                <resource>
-                    <directory>src/main/resources/deploy</directory>
-                    <filtering>true</filtering>
-                </resource>
-            </resources>
-        </build>
-    </profile>
     <profile>
       <id>jetty</id>
       <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <sonar.jdbc.password>sonar</sonar.jdbc.password>
     <sonar.host.url>http://127.0.0.1:8080</sonar.host.url>
     <sonar.projectName>esb-message-admin</sonar.projectName>
-    <jenkins.build.number>1</jenkins.build.number>
+    <ci.buildNumber>1</ci.buildNumber>
   </properties>
   <distributionManagement>
     <repository>
@@ -345,7 +345,7 @@
                     <configuration>
                         <getRevisionOnlyOnce>true</getRevisionOnlyOnce>
                         <name>generated.rpm.release</name>
-                        <value>${jenkins.build.number}.${parsedVersion.qualifier}.${buildNumber}</value>
+                        <value>${ci.buildNumber}.${parsedVersion.qualifier}.${buildNumber}</value>
                         <regex>\.{2}</regex>
                         <replacement>.</replacement>
                         <failIfNoMatch>false</failIfNoMatch>

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
     <maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
     <maven.compiler.debuglevel>lines,vars,source</maven.compiler.debuglevel>
     <maven.compiler.verbose>true</maven.compiler.verbose>
+    <rpm.build.disabled>true</rpm.build.disabled>
     <rpm.group>ESB Message Admin</rpm.group>
     <rpm.copyright>esbtools Contributors</rpm.copyright>
     <rpm.filemode>744</rpm.filemode>
@@ -307,6 +308,114 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+      <profile>
+        <id>rpm</id>
+        <!-- RPM packing -->
+        <build>
+            <plugins>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>buildnumber-maven-plugin</artifactId>
+                    <version>1.3</version>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>create</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <getRevisionOnlyOnce>true</getRevisionOnlyOnce>
+                        <shortRevisionLength>7</shortRevisionLength>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>build-helper-maven-plugin</artifactId>
+                    <version>1.9.1</version>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>parse-version</goal>
+                                <goal>regex-property</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <getRevisionOnlyOnce>true</getRevisionOnlyOnce>
+                        <name>generated.rpm.release</name>
+                        <value>${jenkins.build.number}.${parsedVersion.qualifier}.${buildNumber}</value>
+                        <regex>\.{2}</regex>
+                        <replacement>.</replacement>
+                        <failIfNoMatch>false</failIfNoMatch>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>rpm-maven-plugin</artifactId>
+                    <version>2.1.2</version>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>attached-rpm</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <disabled>${rpm.build.disabled}</disabled>
+                        <name>${project.artifactId}</name>
+                        <release>${generated.rpm.release}</release>
+                        <group>${rpm.group}</group>
+                        <copyright>${rpm.copyright}</copyright>
+                        <summary>${rpm.summary}</summary>
+                        <epoch>1</epoch>
+                        <buildSRPM>true</buildSRPM>
+                        <requires>
+                            <require>jboss-fsw &gt;= 6</require>
+                        </requires>
+                        <sourceEncoding>${project.build.sourceEncoding}</sourceEncoding>
+                        <mappings>
+                            <mapping>
+                                <directory>${rpm.war.directory}</directory>
+                                <filemode>${rpm.filemode}</filemode>
+                                <username>${rpm.username}</username>
+                                <groupname>${rpm.groupname}</groupname>
+                                <sources>
+                                    <source>
+                                        <location>target/${project.artifactId}-${project.version}.war</location>
+                                    </source>
+                                </sources>
+                            </mapping>
+                            <mapping>
+                                <directory>${rpm.jcliff.directory}</directory>
+                                <filemode>${rpm.filemode}</filemode>
+                                <username>${rpm.username}</username>
+                                <groupname>${rpm.groupname}</groupname>
+                                <sources>
+                                    <source>
+                                      <location>${project.build.outputDirectory}/${project.artifactId}.deploy</location>
+                                    </source>
+                                </sources>
+                            </mapping>
+                        </mappings>
+                    </configuration>
+                </plugin>
+            </plugins>
+            <resources>
+                <resource>
+                    <directory>src/main/resources</directory>
+                    <filtering>false</filtering>
+                    <excludes>
+                        <exclude>deploy/*.deploy</exclude>
+                    </excludes>
+                </resource>
+                <resource>
+                    <directory>src/main/resources/deploy</directory>
+                    <filtering>true</filtering>
+                </resource>
+            </resources>
+        </build>
     </profile>
   </profiles>
 </project>

--- a/rest-save-cert-auth/pom.xml
+++ b/rest-save-cert-auth/pom.xml
@@ -13,7 +13,7 @@
   <name>esb-message-admin: ${project.groupId}|${project.artifactId}</name>
   <properties>
     <rpm.summary>ESB Message Admin REST Save</rpm.summary>
-    <rpm.release>1</rpm.release>
+    <rpm.build.disabled>false</rpm.build.disabled>
   </properties>
   <dependencies>
     <dependency>
@@ -105,76 +105,4 @@
       </resource>
     </resources>
   </build>
-  <profiles>
-    <profile>
-      <id>rpm</id>
-      <!-- RPM packing -->
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>rpm-maven-plugin</artifactId>
-            <version>2.1.2</version>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>attached-rpm</goal>
-                </goals>
-              </execution>
-            </executions>
-            <configuration>
-              <name>esb-message-admin-${project.artifactId}</name>
-              <release>${rpm.release}</release>
-              <group>${rpm.group}</group>
-              <copyright>${rpm.copyright}</copyright>
-              <summary>${rpm.summary}</summary>
-              <epoch>1</epoch>
-              <buildSRPM>true</buildSRPM>
-              <requires>
-                <require>jboss-fsw &gt;= 6</require>
-              </requires>
-              <sourceEncoding>${project.build.sourceEncoding}</sourceEncoding>
-              <mappings>
-                <mapping>
-                  <directory>${rpm.war.directory}</directory>
-                  <filemode>${rpm.filemode}</filemode>
-                  <username>${rpm.username}</username>
-                  <groupname>${rpm.groupname}</groupname>
-                  <sources>
-                    <source>
-                      <location>target/${project.artifactId}-${project.version}.war</location>
-                    </source>
-                  </sources>
-                </mapping>
-                <mapping>
-                  <directory>${rpm.jcliff.directory}</directory>
-                  <filemode>${rpm.filemode}</filemode>
-                  <username>${rpm.username}</username>
-                  <groupname>${rpm.groupname}</groupname>
-                  <sources>
-                    <source>
-                      <location>${project.build.outputDirectory}/${project.artifactId}.deploy</location>
-                    </source>
-                  </sources>
-                </mapping>
-              </mappings>
-            </configuration>
-          </plugin>
-        </plugins>
-        <resources>
-          <resource>
-            <directory>src/main/resources</directory>
-            <filtering>false</filtering>
-            <excludes>
-              <exclude>deploy/*.deploy</exclude>
-            </excludes>
-          </resource>
-          <resource>
-            <directory>src/main/resources/deploy</directory>
-            <filtering>true</filtering>
-          </resource>
-        </resources>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/rest-save/pom.xml
+++ b/rest-save/pom.xml
@@ -13,7 +13,7 @@
   <name>esb-message-admin: ${project.groupId}|${project.artifactId}</name>
   <properties>
     <rpm.summary>ESB Message Admin REST Save</rpm.summary>
-    <rpm.release>1</rpm.release>
+    <rpm.build.disabled>false</rpm.build.disabled>
   </properties>
   <dependencies>
     <dependency>
@@ -93,76 +93,4 @@
       </resource>
     </resources>
   </build>
-  <profiles>
-    <profile>
-      <id>rpm</id>
-      <!-- RPM packing -->
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>rpm-maven-plugin</artifactId>
-            <version>2.1.2</version>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>attached-rpm</goal>
-                </goals>
-              </execution>
-            </executions>
-            <configuration>
-              <name>esb-message-admin-${project.artifactId}</name>
-              <release>${rpm.release}</release>
-              <group>${rpm.group}</group>
-              <copyright>${rpm.copyright}</copyright>
-              <summary>${rpm.summary}</summary>
-              <epoch>1</epoch>
-              <buildSRPM>true</buildSRPM>
-              <requires>
-                <require>jboss-fsw &gt;= 6</require>
-              </requires>
-              <sourceEncoding>${project.build.sourceEncoding}</sourceEncoding>
-              <mappings>
-                <mapping>
-                  <directory>${rpm.war.directory}</directory>
-                  <filemode>${rpm.filemode}</filemode>
-                  <username>${rpm.username}</username>
-                  <groupname>${rpm.groupname}</groupname>
-                  <sources>
-                    <source>
-                      <location>target/${project.artifactId}-${project.version}.war</location>
-                    </source>
-                  </sources>
-                </mapping>
-                <mapping>
-                  <directory>${rpm.jcliff.directory}</directory>
-                  <filemode>${rpm.filemode}</filemode>
-                  <username>${rpm.username}</username>
-                  <groupname>${rpm.groupname}</groupname>
-                  <sources>
-                    <source>
-                      <location>${project.build.outputDirectory}/${project.artifactId}.deploy</location>
-                    </source>
-                  </sources>
-                </mapping>
-              </mappings>
-            </configuration>
-          </plugin>
-        </plugins>
-        <resources>
-          <resource>
-            <directory>src/main/resources</directory>
-            <filtering>false</filtering>
-            <excludes>
-              <exclude>deploy/*.deploy</exclude>
-            </excludes>
-          </resource>
-          <resource>
-            <directory>src/main/resources/deploy</directory>
-            <filtering>true</filtering>
-          </resource>
-        </resources>
-      </build>
-    </profile>
-  </profiles>
 </project>


### PR DESCRIPTION
- rpm build now in parent pom rather than child poms (disabled by default to account for children who cant build rpms, must enable in children via property <rpm.build.disabled>false</rpm.build.disabled>)

- changed rpm versioning format to include jenkins build number and got commit hash