### PR TITLE
Disable textarea for messages that are not editable

### DIFF
--- a/app/src/main/webapp/app/error/errors.tpl.html
+++ b/app/src/main/webapp/app/error/errors.tpl.html
@@ -49,7 +49,7 @@
                                     <button type="button" class="btn btn-primary" ng-click='resubmitMessage()'>Resubmit message</button>
                                     <br/>
                                     <br/>
-                                    <textarea class="payload" ng-trim="true">{{message.payload}}</textarea>
+                                    <textarea class="payload" ng-trim="true" ng-disabled="!message.editableMessage">{{message.payload}}</textarea>
                                 </form>
                             </tab>
                             <tab heading="Headers">


### PR DESCRIPTION
It's unclear if a message can be edited now. In fact, it was possible to edit a message, that would only be resubmitted in its original form.